### PR TITLE
add first dragging functionality / fix error on reload due to printing

### DIFF
--- a/resources/public/example.css
+++ b/resources/public/example.css
@@ -4,6 +4,22 @@ div, h1, input {
     color: #777;
 }
 
+@keyframes dash {
+  to {
+    stroke-dashoffset: -1000;
+  }
+}
+
+.connector {
+    stroke: black;
+    stroke-dasharray: 20;
+    animation: dash 30s linear infinite;
+}
+
+.ghost-entity {
+    opacity: 0.5;
+}
+
 .example-clock {
     font-size: 128px;
     line-height: 1.2em;

--- a/resources/public/example.css
+++ b/resources/public/example.css
@@ -20,6 +20,10 @@ div, h1, input {
     opacity: 0.5;
 }
 
+.animated-entity {
+    transition: 1s ease-in-out;
+}
+
 .example-clock {
     font-size: 128px;
     line-height: 1.2em;

--- a/src/rp-companion/core.cljs
+++ b/src/rp-companion/core.cljs
@@ -12,6 +12,7 @@
            [goog.history EventType]))
 
 `(devtools/install!)
+(enable-console-print!)
 
 (def app-node (js/document.getElementById "app"))
 

--- a/src/rp-companion/master.cljs
+++ b/src/rp-companion/master.cljs
@@ -10,9 +10,9 @@
   (fn [_ [_ room-id]]
     {:room-id room-id
      :entities {
-                1 {:position [100 100] :color "red" :id 1 :actions {:next-position [100 100] :will-be-deleted false}}
-                2 {:position [100 500] :color "blue" :id 2 :actions {:next-position [100 500] :will-be-deleted false}}
-                3 {:position [50 20] :color "orang" :id 3 :actions {:next-position [50 20] :will-be-deleted false}}}}))
+                1 {:position [100 100] :color "red" :id 1 :actions {:next-position nil :will-be-deleted false}}
+                2 {:position [100 500] :color "blue" :id 2 :actions {:next-position nil :will-be-deleted false}}
+                3 {:position [50 20] :color "orang" :id 3 :actions {:next-position nil :will-be-deleted false}}}}))
 
 (rf/reg-event-db
   :add-entity
@@ -21,6 +21,16 @@
           x (* 300 (Math/random))
           y (* 300 (Math/random))]
     (assoc-in db [:entities id] {:position [x y] :color "yellow" :id id} ))))
+
+(rf/reg-event-db
+  :add-ghost
+ (fn [db [_ data]]
+   (let [id (:id data)
+         curr-pos (:curr-pos data)
+         next-pos (:next-pos data)]
+     (if (nil? next-pos)
+       (assoc-in db [:entities id :actions :next-position] curr-pos)
+       db))))
 
  (rf/reg-event-db
    :update-next-position
@@ -33,10 +43,14 @@
   :apply-next-pos
   (fn [db _]
       (let [entities (:entities db)
-            updated-entities (apply hash-map
-                                    (flatten (map (fn [[key entity]]
-                                       (let [new-position (get-in entity [:actions :next-position])]
-                                              [key (assoc entity :position new-position)])) entities)))]
+            updated-entities (->> (map (fn [[key entity]]
+                                        (let [old-position (:position entity)
+                                               new-position (get-in entity [:actions :next-position])]
+                                          [key (-> entity
+                                                (assoc :position (or new-position old-position))
+                                                (assoc-in [:actions :next-position] nil))])) entities)
+                                 (flatten)
+                                 (apply hash-map))]
              (assoc db :entities updated-entities))))
 
 ;; Subscriptions
@@ -59,27 +73,35 @@
     actions :actions
     id :id}]
       (let [next-pos (:next-position actions)
-            next-x (first next-pos)
-            next-y (second next-pos)]
+            [next-x next-y] next-pos]
            [:g {:key id}
-            (when (or (not= x next-x) (not= y next-y))
-                  [:line.connector {:x1 x
-                    :y1 y
-                    :x2 next-x
-                    :y2 next-y}])
-            [:circle {:cx x
-                      :cy y
-                      :r 20
-                      :fill color}]
-            [:circle.ghost-entity {:cx next-x
-                                   :cy next-y
-                                   :r 20
-                                   :fill color
-                                   :on-touch-move (fn [event]
-                                                    (let [touches (.. event -changedTouches)
-                                                          touch (.item touches 0)
-                                                          touch-x (.-clientX touch)
-                                                          touch-y (.-clientY touch)]
+            (when (some? next-pos)
+              [:line.connector {:x1 x
+                                :y1 y
+                                :x2 next-x
+                                :y2 next-y}])
+            (when (some? next-pos)
+              [:circle.ghost-entity {:transform (str "translate(" next-x "," next-y ")")
+                                     :r 20
+                                     :fill color
+                                     :on-touch-move (fn [event]
+                                                      (let [touches (.. event -changedTouches)
+                                                            touch (.item touches 0)
+                                                            touch-x (.-clientX touch)
+                                                            touch-y (.-clientY touch)]
+                                                        (rf/dispatch [:update-next-position {:id id :position [touch-x touch-y]}])))}])
+            [:circle.animated-entity {:transform (str "translate(" x "," y ")")
+                                      :r 20
+                                      :fill color
+                                      :on-touch-start (fn [event]
+                                                        (rf/dispatch [:add-ghost {:id id
+                                                                                  :curr-pos [x y]
+                                                                                  :next-pos next-pos}]))
+                                      :on-touch-move (fn [event]
+                                                       (let [touches (.. event -changedTouches)
+                                                             touch (.item touches 0)
+                                                             touch-x (.-clientX touch)
+                                                             touch-y (.-clientY touch)]
                                                          (rf/dispatch [:update-next-position {:id id :position [touch-x touch-y]}])))}]]))
 
 (defn entities-view [{:keys [entities]}]


### PR DESCRIPTION
### Entity Dragging
- Change data model to a simpler structure
- fix for page reload error caused by println function
- added basic functionality for dragging
- Ghost entity for next_position
- Ghost line from position to next_position
- apply next_position function 

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/16529337/43457954-a111365c-94c8-11e8-9ee3-99aeb75f2ee6.gif)
